### PR TITLE
manually try to fix js pack resources mngt - the clone of the pipelin…

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -14,13 +14,11 @@ spec:
           env:
           - name: NPM_CONFIG_USERCONFIG
             value: /tekton/home/npm/.npmrc
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
+          image: uses:LFS268-laucapgemini/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here
-            limits:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -35,8 +33,8 @@ spec:
           resources:
             # override requests for the pod here
             requests:
-              cpu: 0.1
-              memory: 128Mi
+              cpu: 400m
+              memory: 512Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test


### PR DESCRIPTION
…e catalog was not taken into account due to hash code hard coded in the gitops config